### PR TITLE
Update CODEOWNERS to use steak-holders team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 # assigned to each repo and setting them as CodeOwner over the
 # entire repository
 
-* @StrongMind/horseshoes
+* @StrongMind/steak-holders


### PR DESCRIPTION
This PR updates the CODEOWNERS file to use the steak-holders team.

Changes made:
- Replaced '* @StrongMind/horseshoes' with '* @StrongMind/steak-holders'
